### PR TITLE
Removed external process

### DIFF
--- a/src/fact.sh
+++ b/src/fact.sh
@@ -10,4 +10,4 @@ if [ $1 == 0 ]; then
 	exit
 fi
 
-seq -s "*" 1 $1 | bc | tr -dc "0-9"
+echo $(( $(seq -s "*" 1 $1) ))


### PR DESCRIPTION
`bc` is not required for simple arithmetic since bash can do it already.