### PR TITLE
Add proper Makefile support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,55 @@
+# Prerequisites
+*.d
+
+# Object files
+*.o
+*.ko
+*.obj
+*.elf
+
+# Linker output
+*.ilk
+*.map
+*.exp
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Libraries
+*.lib
+*.a
+*.la
+*.lo
+
+# Shared objects (inc. Windows DLLs)
+*.dll
+*.so
+*.so.*
+*.dylib
+
+# Executables
+*.exe
+*.out
+*.app
+*.i*86
+*.x86_64
+*.hex
+
+# Debug files
+*.dSYM/
+*.su
+*.idb
+*.pdb
+
+# Kernel Module Compile Results
+*.mod*
+*.cmd
+.tmp_versions/
+modules.order
+Module.symvers
+Mkfile.old
+dkms.conf
+
+# Binaries
+bashmath

--- a/Makefile
+++ b/Makefile
@@ -30,4 +30,4 @@ clean:
 	$(MAKE) -C bash-loadables/bash clean
 	rm -rf $(OBJS) bashmath bash-loadables/bash/Makefile
 
-.PHONY: clean
+.PHONY: install clean

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,33 @@
+CXX := $(shell (clang++ -v >/dev/null 2>&1 && echo clang++) || (g++ -v >/dev/null 2>&1 && echo g++))
+
+INCS := -I"bash-loadables" -I"bash-loadables/bash/include"
+
+CFLAGS := -flto -Oz -s -Wno-parentheses -Wno-format-security -fvisibility=hidden 
+CFLAGS += -fno-asynchronous-unwind-tables -fno-unwind-tables  -fmerge-all-constants
+
+LDFLAGS := -shared -Wl,-soname,$@ -Wl,-icf=all,--gc-sections -flto -Wl,--plugin-opt=O3 -fuse-ld=lld
+
+SRCS := $(shell find src/ -name '*.cpp')
+OBJS := $(SRCS:.cpp=.o)
+BASHDEPS := $(addprefix bash-loadables/bash/, $(shell $(MAKE) -f helper.mk))
+
+bashmath: $(OBJS)
+	$(CXX) -fPIC $(LDFLAGS) $(LIBS) $(OBJS) -o $@
+
+%.o: %.cpp bash-loadables/bash/bash
+	$(CXX) -fPIC -c $(CXXFLAGS) $(CFLAGS) $(INCS) -o $@ $<
+
+bash-loadables/bash/bash: bash-loadables/bash/Makefile $(BASHDEPS)
+	$(MAKE) -C bash-loadables/bash
+
+bash-loadables/bash/Makefile: bash-loadables/bash/configure
+	cd bash-loadables/bash && ./configure
+
+install: bashmath
+	cp bashmath /bin/bashmath
+
+clean:
+	$(MAKE) -C bash-loadables/bash clean
+	rm -rf $(OBJS) bashmath bash-loadables/bash/Makefile
+
+.PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,10 @@ CXX := $(shell (clang++ -v >/dev/null 2>&1 && echo clang++) || (g++ -v >/dev/nul
 
 INCS := -I"bash-loadables" -I"bash-loadables/bash/include"
 
-CFLAGS := -flto -Oz -s -Wno-parentheses -Wno-format-security -fvisibility=hidden 
+CFLAGS := -flto -Oz -Wno-parentheses -Wno-format-security -fvisibility=hidden 
 CFLAGS += -fno-asynchronous-unwind-tables -fno-unwind-tables  -fmerge-all-constants
 
-LDFLAGS := -shared -Wl,-soname,$@ -Wl,-icf=all,--gc-sections -flto -Wl,--plugin-opt=O3 -fuse-ld=lld
+LDFLAGS := -s -shared -Wl,-soname,$@ -Wl,-icf=all,--gc-sections -flto -Wl,--plugin-opt=O3 -fuse-ld=lld
 
 SRCS := $(shell find src/ -name '*.cpp')
 OBJS := $(SRCS:.cpp=.o)

--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ bash-loadables/bash/Makefile: bash-loadables/bash/configure
 	cd bash-loadables/bash && ./configure
 
 install: bashmath
-	cp bashmath /bin/bashmath
+	cp bashmath /usr/local/lib/bashmath
 
 clean:
 	$(MAKE) -C bash-loadables/bash clean

--- a/README.md
+++ b/README.md
@@ -30,14 +30,12 @@ Bashmash is powered by:
  - G++: `sudo apt install g++`
  - Clang: `sudo apt install clang`
  - LLD: `sudo apt install lld`
- - cap-ng.h: `sudo apt install libcap-ng-dev`
- - seccomp.h: `sudo apt install libseccomp-dev`
 
 ### Steps
-1. Clone this repository including the submodules: `git clone --recurse-submodules https://github.com/HubertPastyrzak/Bashmash`.
-2. Go to the downloaded folder: `cd Bashmash`.
-3. Run the installer: `sudo ./install.sh`.
-4. Bashmash is now ready to use. :)
+ 1. Clone this repository including the submodules: `git clone --recurse-submodules https://github.com/HubertPastyrzak/Bashmash`.
+ 2. Go to the downloaded folder: `cd Bashmash`.
+ 3. Run the installer: `./install.sh`.
+ 4. Bashmash is now ready to use. :)
 
 ## Importing commands
 ```bash

--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ Bashmash is powered by:
 
 ## Importing commands
 ```bash
-enable -f /bin/bashmash <command>
+enable -f /usr/local/lib/bashmash <command>
 
 
 
 Example:
 
-enable -f /bin/bashmash dec2bin
+enable -f /usr/local/lib/bashmash dec2bin
 ```
 
 ## Usage

--- a/helper.mk
+++ b/helper.mk
@@ -1,0 +1,9 @@
+# Use conditional include to suppress error when ./configure isn't called on bash-loadables/bash/
+-include bash-loadables/bash/Makefile
+
+print_sources:
+	@/bin/echo $(SOURCES)
+
+.PHONY: print_sources
+
+.DEFAULT_GOAL := print_sources

--- a/install.sh
+++ b/install.sh
@@ -1,34 +1,18 @@
 #!/bin/bash
 
-if [ $EUID != 0 ]; then
-	echo "You must run this installer as root."
-	echo "Use this command: sudo ./install.sh"
-	
-	exit
-fi
-
 name="Bashmash"
 version="0.5"
 
-if ! command -v g++ &> /dev/null; then
-	echo "You must install G++ to install $name $version."
-	echo "Use this command: sudo apt install g++"
+if (! command -v g++ &> /dev/null) && (! command -v clang++ &>/dev/null); then
+	echo "You must install g++ or clang++ to install $name $version."
+	echo "Use this command: sudo apt install clang++ g++"
 	
 	exit
 fi
 
 echo "Installing $name $version..."
-cd bash-loadables/bash
 
-./configure
-make
-
-cd ..
-make all -j $(nproc)
-
-cd ..
-g++ "src/Bashmash.cpp" "src/math/fact.cpp" "src/math/bico.cpp" "src/bitwise/not.cpp" "src/bitwise/or.cpp" "src/bitwise/and.cpp" "src/bitwise/xor.cpp" "src/comparators/cless.cpp" "src/comparators/cleq.cpp" "src/comparators/ceq.cpp" "src/comparators/cgreq.cpp" "src/comparators/cgreat.cpp" "src/converters/bin2oct.cpp" "src/converters/bin2dec.cpp" "src/converters/bin2hex.cpp" "src/converters/oct2bin.cpp" "src/converters/oct2dec.cpp" "src/converters/oct2hex.cpp" "src/converters/dec2bin.cpp" "src/converters/dec2oct.cpp" "src/converters/dec2hex.cpp" "src/converters/hex2bin.cpp" "src/converters/hex2oct.cpp" "src/integers/Integer.cpp" "src/converters/hex2dec.cpp" "src/integers/NonNegativeBinaryInteger.cpp" "src/integers/NonNegativeOctalInteger.cpp" "src/integers/NonNegativeInteger.cpp" "src/integers/NonNegativeHexadecimalInteger.cpp" -I"bash-loadables" -I"bash-loadables/bash/include" -o "/bin/bashmash" -shared -fPIC
-
+make -j $(nproc) && sudo make install
 if [ $? != 0 ]; then
 	echo "Errors have occurred while installing $name $version."
 	echo "Please fix the above errors and try again."


### PR DESCRIPTION
 - Add proper Makefile support to this project and simplify the building process.
 - Support clang++
 - Also add a few more CFLAGS and LDFLAGS to Makefile.
 - Install `bashmath` to `/usr/local/lib/` instead of `/bin`.
 - Add .gitignore.